### PR TITLE
Fix card text overflow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -40,6 +40,7 @@
 .rich-link-card .rich-link-card-text {
   padding: 4px;
   width: 75%;
+  overflow: hidden;
 }
 
 .rich-link-card .rich-link-card-title {


### PR DESCRIPTION
This fixes the text from overflowing in the rich-link-card-text container.