### PR TITLE
Fix preview image not found for some sites

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -63,7 +63,7 @@ export default class ObsidianRichLinksPlugin extends Plugin {
         url: `http://iframely.server.crestify.com/iframely?url=${url}`,
       }).then((res) => {
 		  const data = JSON.parse(res);
-		  const imageLink = data.links[0].href || '';
+		  const imageLink = data.links.find(value => value.type.startsWith("image/")).href || '';
 
         editor.replaceSelection(`
 <div class="rich-link-card-container"><a class="rich-link-card" href="${url}" target="_blank">


### PR DESCRIPTION
Instead of grabbing the first link we itirate over the links and look for one of type image `value.type.startsWith("image/"))`
close #15 