### PR TITLE
change, to consume only a single line in Obsidian

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -64,36 +64,21 @@ export default class ObsidianRichLinksPlugin extends Plugin {
       }).then((res) => {
 		  const data = JSON.parse(res);
 		  const imageLink = data.links.find((value: { type: string; }) => value.type.startsWith("image/")).href || '';
-
-        editor.replaceSelection(`
-<div class="rich-link-card-container"><a class="rich-link-card" href="${url}" target="_blank">
-	<div class="rich-link-image-container">
-		<div class="rich-link-image" style="background-image: url('${imageLink}')">
-	</div>
-	</div>
-	<div class="rich-link-card-text">
-		<h1 class="rich-link-card-title">${(data.meta.title || "").replace(/\s{3,}/g, ' ').trim()}</h1>
-		<p class="rich-link-card-description">
-		${(data.meta.description || "").replace(/\s{3,}/g, ' ').trim()}
-		</p>
-		<p class="rich-link-href">
-		${url}
-		</p>
-	</div>
-</a></div>
-
-`);
-      });
-    } else {
-      new Notice("Select a URL to convert to rich link.");
+                editor.replaceSelection(`<div class="rich-link-card-container"><a class="rich-link-card" href="${url}" target="_blank"><div class="rich-link-image-container"><div class="rich-link-image" style="background-image: url('${imageLink}')">	</div></div><div class="rich-link-card-text"><h1 class="rich-link-card-title">${(data.meta.title || "").replace(/\s{3,}/g, ' ').trim()}</h1><p class="rich-link-card-description">${(data.meta.description || "").replace(/\s{3,}/g, ' ').trim()}</p><p class="rich-link-href">${url}</p></div></a></div>`);
+            });
+        }
+        else {
+            new obsidian.Notice("Select a URL to convert to rich link.");
+        }
     }
-  }
-
-  async loadSettings() {
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-  }
-
-  async saveSettings() {
-    await this.saveData(this.settings);
-  }
+    loadSettings() {
+        return __awaiter(this, void 0, void 0, function* () {
+            this.settings = Object.assign({}, DEFAULT_SETTINGS, yield this.loadData());
+        });
+    }
+    saveSettings() {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield this.saveData(this.settings);
+        });
+    }
 }


### PR DESCRIPTION
Hi, 
your plug-in is really great! 

The only thing that bothered me, was that multiple lines in Obsidian are consumed. 
The is not so ideal and handy, if you need to work with the link later and move it around. 
So, I simply changed it, to remove all the line breaks in the replacement text, turning it into a single line of code. 
On the downturn, more difficult to read, but if needed, the snippet could be beautified via online tool. 
But on the upturn, the moving around the item is now much simpler. 

Thank you! Please consider getting my change into your main branch and publish it with your next release. 

Kind Regards
Michael Kiessling
 